### PR TITLE
Fix Dart template build failure (404 error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Dart
       uses: dart-lang/setup-dart@v1
       with:
-        sdk: '>=2.12.0 <3.0.0'
+        sdk: '2.12.0'
 
     - name: Install dependencies
       run: dart pub get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Dart package for demonstrating functionality.
 version: 0.1.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '2.12.0'
 
 dependencies:
   path: ^1.8.0


### PR DESCRIPTION
Fixes #1

Update Dart SDK version in GitHub Actions workflow and `pubspec.yaml` to fix build failure.

* **GitHub Actions Workflow**
  - Change Dart SDK version in `.github/workflows/ci.yml` from `'>=2.12.0 <3.0.0'` to `2.12.0`.

* **pubspec.yaml**
  - Change Dart SDK version in `pubspec.yaml` from `'>=2.12.0 <3.0.0'` to `2.12.0`.

